### PR TITLE
Faster meshing and misc. changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ if (APPLE)
     set(LLVM_DIR /opt/homebrew/opt/llvm/lib/cmake/llvm)
 endif ()
 find_package(LLVM REQUIRED CONFIG)
+find_package(TBB REQUIRED)
 
 add_executable(implicit_meshing
         main.cpp
@@ -45,6 +46,7 @@ target_link_libraries(implicit_meshing PRIVATE
         LLVMARMAsmParser
         LLVMAArch64CodeGen
         LLVMAArch64AsmParser
+        TBB::tbb
 )
 
 target_compile_options(implicit_meshing PRIVATE -march=native)

--- a/compiler.cpp
+++ b/compiler.cpp
@@ -80,6 +80,9 @@ std::function<double(glm::dvec3)> compile(std::vector<Instruction>& instructions
                 // Assuming sqrt function is available in your LLVM setup
                 result = builder.CreateCall(module->getOrInsertFunction("llvm.sqrt.f64", funcType), lhs, "sqrttmp");
                 break;
+            case Operation::Neg:
+                result = builder.CreateFNeg(lhs, "negtmp");
+                break;
             case Operation::Min:
                 // Implement Min operation
                 result = builder.CreateSelect(builder.CreateFCmpULT(lhs, rhs), lhs, rhs);
@@ -182,6 +185,12 @@ glm::ivec2 generate_sub (std::vector<Instruction>& instructions, int& current_re
 
 int generate_sub (std::vector<Instruction>& instructions, int& current_register, int v1, int v2) {
     Instruction i1 = {v1, v2, current_register++, Operation::Sub};
+    instructions.insert(instructions.end(), {i1});
+    return i1.output;
+}
+
+int generate_neg (std::vector<Instruction>& instructions, int& current_register, int v) {
+    Instruction i1 = {v, -1, current_register++, Operation::Neg};
     instructions.insert(instructions.end(), {i1});
     return i1.output;
 }
@@ -295,6 +304,8 @@ const char* return_op_name(Operation op){
             return "Mul";
         case Operation::Sqrt:
             return "Sqrt";
+        case Operation::Neg:
+            return "Neg";
         case Operation::Min:
             return "Min";
         case Operation::Max:

--- a/compiler.h
+++ b/compiler.h
@@ -16,6 +16,7 @@ enum class Operation {
     Sub,
     Mul,
     Sqrt,
+    Neg,
     Min,
     Max,
     Abs,
@@ -45,6 +46,8 @@ glm::ivec3 generate_sub (std::vector<Instruction>& instructions, int& current_re
 glm::ivec2 generate_sub (std::vector<Instruction>& instructions, int& current_register, glm::ivec2 v1, glm::ivec2 v2);
 
 int generate_sub (std::vector<Instruction>& instructions, int& current_register, int v1, int v2);
+
+int generate_neg (std::vector<Instruction>& instructions, int& current_register, int v);
 
 int generate_add (std::vector<Instruction>& instructions, int& current_register, int v1, int v2);
 

--- a/editor.cpp
+++ b/editor.cpp
@@ -86,6 +86,14 @@ void Editor::draw_operator_dropdown() {
             selected_node = 1;
             add_node<SmoothUnionNode>();
         }
+        if (ImGui::Selectable("Intersection", selected_node == 2)) {
+            selected_node = 2;
+            add_node<IntersectionNode>();
+        }
+        if (ImGui::Selectable("Subtraction", selected_node == 3)) {
+            selected_node = 3;
+            add_node<SubtractionNode>();
+        }
         ImGui::EndCombo();
     }
     ImGui::PopItemWidth();

--- a/implicit_meshing.cpp
+++ b/implicit_meshing.cpp
@@ -190,7 +190,6 @@ struct Task {
 
                     GridCell child_cell(child_min, child_max);
                     tg.run(Task{child_cell, data});
-                    //grid_cells.push_back(child_cell);
                 }
             }
         }
@@ -212,9 +211,9 @@ QuadMesh mesh_generator(std::function<double(glm::dvec3)> f, int n) {
 
     auto gradient_f = [=](glm::dvec3 p) -> glm::dvec3 {
         double eps = 10e-6;
-        double dx = (f({p.x + eps, p.y, p.z}) - f({p.x - eps, p.y, p.z})) / (2*eps);
-        double dy = (f({p.x, p.y + eps, p.z}) - f({p.x, p.y - eps, p.z})) / (2*eps);
-        double dz = (f({p.x, p.y, p.z + eps}) - f({p.x, p.y, p.z - eps})) / (2*eps);
+        double dx = (f({p.x + eps, p.y, p.z}) - f({p.x - eps, p.y, p.z})) / (2 * eps);
+        double dy = (f({p.x, p.y + eps, p.z}) - f({p.x, p.y - eps, p.z})) / (2 * eps);
+        double dz = (f({p.x, p.y, p.z + eps}) - f({p.x, p.y, p.z - eps})) / (2 * eps);
         return {dx, dy, dz};
     };
 
@@ -236,12 +235,12 @@ QuadMesh mesh_generator(std::function<double(glm::dvec3)> f, int n) {
     GridMap grid;
     {
         size_t counter = 0;
-        for(auto& local_grid : grids) {
+        for (auto &local_grid: grids) {
             counter += local_grid.size();
         }
         grid.reserve(counter);
-        for(const auto& local_grid : grids) {
-            for(const auto& element : local_grid) {
+        for (const auto &local_grid: grids) {
+            for (const auto &element: local_grid) {
                 grid.insert_unique(element.first, element.second);
             }
         }

--- a/node.cpp
+++ b/node.cpp
@@ -484,6 +484,73 @@ UnionNode::generate_instructions(std::vector<Instruction> &instructions, int &cu
     return {generate_min(instructions, current_register, v1[0], v2[0])};
 }
 
+void IntersectionNode::draw() {
+    ImGui::PushItemWidth(120);
+    ImNodes::BeginNode(m_node_id);
+
+    ImNodes::BeginNodeTitleBar();
+    ImGui::TextUnformatted("Intersection");
+    ImNodes::EndNodeTitleBar();
+
+    ImGui::Dummy(ImVec2(120.0f, 0.0f));
+    assert(m_num_inputs == 2);
+    ImNodes::BeginInputAttribute(m_editor->get_input_attribute_id(m_node_id, 0));
+    ImGui::Text("Implicit 1");
+    ImNodes::EndInputAttribute();
+    ImNodes::BeginInputAttribute(m_editor->get_input_attribute_id(m_node_id, 1));
+    ImGui::Text("Implicit 2");
+    ImNodes::EndInputAttribute();
+
+    ImNodes::BeginOutputAttribute(m_editor->get_output_attribute_id(m_node_id));
+    ImNodes::EndOutputAttribute();
+    ImNodes::EndNode();
+    ImGui::PopItemWidth();
+}
+
+std::vector<int>
+IntersectionNode::generate_instructions(std::vector<Instruction> &instructions, int &current_register,
+                                 std::map<int, double> &constants) {
+    Node *node_input1 = m_editor->find_node(m_node_id, 0);
+    Node *node_input2 = m_editor->find_node(m_node_id, 1);
+    std::vector<int> v1 = node_input1->generate_instructions(instructions, current_register, constants);
+    std::vector<int> v2 = node_input2->generate_instructions(instructions, current_register, constants);
+    return {generate_max(instructions, current_register, v1[0], v2[0])};
+}
+
+void SubtractionNode::draw() {
+    ImGui::PushItemWidth(120);
+    ImNodes::BeginNode(m_node_id);
+
+    ImNodes::BeginNodeTitleBar();
+    ImGui::TextUnformatted("Intersection");
+    ImNodes::EndNodeTitleBar();
+
+    ImGui::Dummy(ImVec2(120.0f, 0.0f));
+    assert(m_num_inputs == 2);
+    ImNodes::BeginInputAttribute(m_editor->get_input_attribute_id(m_node_id, 0));
+    ImGui::Text("Implicit 1");
+    ImNodes::EndInputAttribute();
+    ImNodes::BeginInputAttribute(m_editor->get_input_attribute_id(m_node_id, 1));
+    ImGui::Text("Implicit 2");
+    ImNodes::EndInputAttribute();
+
+    ImNodes::BeginOutputAttribute(m_editor->get_output_attribute_id(m_node_id));
+    ImNodes::EndOutputAttribute();
+    ImNodes::EndNode();
+    ImGui::PopItemWidth();
+}
+
+std::vector<int>
+SubtractionNode::generate_instructions(std::vector<Instruction> &instructions, int &current_register,
+                                        std::map<int, double> &constants) {
+    Node *node_input1 = m_editor->find_node(m_node_id, 0);
+    Node *node_input2 = m_editor->find_node(m_node_id, 1);
+    std::vector<int> v1 = node_input1->generate_instructions(instructions, current_register, constants);
+    std::vector<int> v2 = node_input2->generate_instructions(instructions, current_register, constants);
+    int v = generate_neg(instructions, current_register, v2[0]);
+    return {generate_max(instructions, current_register, v1[0], v)};
+}
+
 void SmoothUnionNode::draw() {
     ImGui::PushItemWidth(120);
     ImNodes::BeginNode(m_node_id);

--- a/node.h
+++ b/node.h
@@ -136,6 +136,26 @@ public:
     generate_instructions(std::vector<Instruction> &instructions, int &current_register, std::map<int, double> &constants) override;
 };
 
+class IntersectionNode : public Node {
+public:
+    IntersectionNode(Editor *editor, int node_id) : Node(editor, node_id, 2) {}
+
+    void draw() override;
+
+    std::vector<int>
+    generate_instructions(std::vector<Instruction> &instructions, int &current_register, std::map<int, double> &constants) override;
+};
+
+class SubtractionNode : public Node {
+public:
+    SubtractionNode(Editor *editor, int node_id) : Node(editor, node_id, 2) {}
+
+    void draw() override;
+
+    std::vector<int>
+    generate_instructions(std::vector<Instruction> &instructions, int &current_register, std::map<int, double> &constants) override;
+};
+
 class SmoothUnionNode : public Node {
 public:
     float m_rounding = 0.05;


### PR DESCRIPTION
This improves the meshing speed by 

- threading all performance critical parts
- using a sparse hashmap instead of a densely populated vector for the index map
- only computing edge points once for each edge in stead of four times.

Together these improved the performance for a simple cylinder by about 10x on my computer.

Also added a intersect and subtract nodes.